### PR TITLE
Support for Click 8.10; Version 1.1.3.post-am2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ IMPORT = 'sphinxcontrib.versioning'
 INSTALL_REQUIRES = ['click', 'colorclass', 'sphinx']
 LICENSE = 'MIT'
 NAME = 'sphinx-versions'
-VERSION = '1.1.3.post-am1'
+VERSION = '1.1.3.post-am2'
 
 
 def readme(path='README.rst'):

--- a/sphinxcontrib/versioning/__main__.py
+++ b/sphinxcontrib/versioning/__main__.py
@@ -1,6 +1,7 @@
 """Entry point of project via setuptools which calls cli()."""
 
 import logging
+import sys
 import os
 import shutil
 import time
@@ -69,7 +70,7 @@ class ClickGroup(click.Group):
 
         :return: super() return value.
         """
-        argv = kwargs.pop('args', click.get_os_args())
+        argv = kwargs.pop('args', sys.argv[1:])
         if '--' in argv:
             pos = argv.index('--')
             argv, self.overflow = argv[:pos], tuple(argv[pos + 1:])


### PR DESCRIPTION
For details, see the commit message.
This is also the release of 1.1.3.post-am2 on this forked repo.

Install with: `pip install git+https://github.com/andy-maier/sphinx-versions.git@andy-fixes#egg=sphinx-versions` (Python 3.6 or higher)